### PR TITLE
Fix delete() for key type different from value type

### DIFF
--- a/rbtree.nim
+++ b/rbtree.nim
@@ -447,7 +447,7 @@ proc delete*[T: TreeElem, K](self: var RedBlackTree[T, K], value: T) =
     ## Deletes a value from the tree
 
     # Find the value we are being asked to delete
-    var toDelete = search(self, value)
+    var toDelete = search(self, getKey(T, K, value))
     if toDelete == nil:
         return
 

--- a/rbtree.nim
+++ b/rbtree.nim
@@ -448,7 +448,7 @@ proc delete*[T: TreeElem, K](self: var RedBlackTree[T, K], value: T) =
 
     # Find the value we are being asked to delete
     var toDelete = search(self, getKey(T, K, value))
-    if toDelete == nil:
+    if toDelete == nil or toDelete.value != value:
         return
 
     # We can't delete a node with two children, so find a predecessor that has

--- a/test/rbtree_test.nim
+++ b/test/rbtree_test.nim
@@ -158,6 +158,9 @@ suite "A Red/Black Tree should":
         require( not tree.contains((x: 40, y: 30)) )
         require( not tree.contains(20) )
 
+        tree.delete((x: 50, y: 4))
+        require( not tree.contains(50) )
+
     test "Return the minimum value in a true":
         var tree = newRBTree[int, int]()
         require( tree.min.isNone )


### PR DESCRIPTION
delete() calls search() with value instead of key. Please see the rbtree_test.nim diff -- it didn't compile before this fix (and I assume it should've).